### PR TITLE
polish: Remove unnecessary warning about embedded Wolfram Player on Windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1013,9 +1013,12 @@ impl WolframApp {
                 .join("Contents")
                 .join("Resources")
                 .join("Wolfram Player.app"),
-            OperatingSystem::Windows
-            | OperatingSystem::Linux
-            | OperatingSystem::Other => {
+            // Wolfram Engine does not contain an embedded Wolfram Player
+            // on Windows.
+            OperatingSystem::Windows => {
+                return Ok(self);
+            },
+            OperatingSystem::Linux | OperatingSystem::Other => {
                 // TODO: Does Wolfram Engine on Linux/Windows contain an embedded Wolfram Player,
                 //       or is that only done on macOS?
                 print_platform_unimplemented_warning(


### PR DESCRIPTION
Wolfram Engine does not include an embedded Wolfram Player on Windows.