### PR TITLE
bugfix: Silence spurious warnings generated on macOS when no instances of an app type exist

### DIFF
--- a/docs/Development.md
+++ b/docs/Development.md
@@ -90,6 +90,7 @@ wolfram-app-discovery default --raw-value library-link-c-includes-directory --al
 
 ```shell
 wolfram-app-discovery list
+wolfram-app-discovery list --app-type mathematica
 wolfram-app-discovery list --format csv
 wolfram-app-discovery list --all-properties
 wolfram-app-discovery list --all-properties --format csv


### PR DESCRIPTION
Most users won't have e.g. Player Pro or Finance Platform platform installed. Printing a warning to the console about it doesn't add any value.

Also fix a leaked CFError object.