### PR TITLE
feature(cli): Support comma-separated values in `--app-type`

### DIFF
--- a/docs/Development.md
+++ b/docs/Development.md
@@ -91,6 +91,7 @@ wolfram-app-discovery default --raw-value library-link-c-includes-directory --al
 ```shell
 wolfram-app-discovery list
 wolfram-app-discovery list --app-type mathematica
+wolfram-app-discovery list --app-type engine,desktop
 wolfram-app-discovery list --format csv
 wolfram-app-discovery list --all-properties
 wolfram-app-discovery list --all-properties --format csv

--- a/src/bin/wolfram-app-discovery/main.rs
+++ b/src/bin/wolfram-app-discovery/main.rs
@@ -66,7 +66,12 @@ enum Command {
 #[derive(Parser)]
 struct DiscoveryOpts {
     /// Wolfram application types to include.
-    #[arg(long = "app-type", value_enum)]
+    #[arg(
+        long = "app-type",
+        // Allow `--properties=prop1,prop2,etc`
+        value_delimiter = ',',
+        value_enum
+    )]
     app_types: Vec<WolframAppType>,
 
     #[clap(flatten)]


### PR DESCRIPTION
For example: `--app-type engine,desktop`