### PR TITLE
remove $ from command line so the copy and paste button works correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ available for all major platforms from the GitHub Releases page.
 (the [Rust package manager](https://doc.rust-lang.org/cargo/)) by executing:
 
 ```shell
-$ cargo install --features=cli wolfram-app-discovery
+cargo install --features=cli wolfram-app-discovery
 ```
 
 This will install the latest version of


### PR DESCRIPTION
Removed the leading $ character so that the copy and paste works without having to remove the $ character in the terminal.

With the leading $ the terminal shell complains (unexpectedly, for me):

```
(base) ~ % $ cargo install --features=cli wolfram-app-discovery
zsh: command not found: $
```