### PR TITLE
Fixes logic in try_default() related to wolframscript and unknown OS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1051,11 +1051,22 @@ impl WolframApp {
         //-----------------------------------------------------------------------
 
         if let Some(dir) = try_wolframscript_installation_directory()? {
-            let app = WolframApp::from_installation_directory(dir)?;
-            // If the app doesn't pass the filter, silently ignore it.
-            if !filter.check_app(&app).is_err() {
-                return Ok(app);
-            }
+	    match WolframApp::from_installation_directory(dir){
+		Ok(app) => {
+		    // If the app doesn't pass the filter, silently ignore it.
+		    if !filter.check_app(&app).is_err() {
+			return Ok(app);
+		    }
+		}
+		,
+		//Ignore UnsupportedPlatform, as discover_with_filter()
+		//may still be able to find the app
+		Err(Error(ErrorKind::UnsupportedPlatform{..})) => {}
+		,
+		Err(err) => {
+		    return Err(err)
+		}
+	    }
         }
 
         //--------------------------------------------------


### PR DESCRIPTION
 Fixes WolframResearch/wolfram-rust-library#1
Allows try_default() to ignore situations where wolframscript is found but from_installtion_directory() doesn't know how to reconstruct the correct path for the current operating system.